### PR TITLE
Improve Google Earth launches on iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,10 +166,42 @@
       <div class="hotspots" aria-label="Suggested hotspots">
         <h3>Try these hotspots:</h3>
         <div class="chips" role="list">
-          <button type="button" role="listitem" data-coords="46.8523,-121.7603">Mount Rainier, USA</button>
-          <button type="button" role="listitem" data-coords="27.9878,86.9250">Himalayas, Nepal</button>
-          <button type="button" role="listitem" data-coords="-16.4897,-68.1193">La Paz, Bolivia</button>
-          <button type="button" role="listitem" data-coords="35.3606,138.7274">Mount Fuji, Japan</button>
+          <button
+            type="button"
+            role="listitem"
+            data-coords="46.8523,-121.7603"
+            data-alt="7500"
+            data-label="Mount Rainier, USA"
+          >
+            Mount Rainier, USA
+          </button>
+          <button
+            type="button"
+            role="listitem"
+            data-coords="27.9878,86.9250"
+            data-alt="12000"
+            data-label="Himalayas, Nepal"
+          >
+            Himalayas, Nepal
+          </button>
+          <button
+            type="button"
+            role="listitem"
+            data-coords="-16.4897,-68.1193"
+            data-alt="5000"
+            data-label="La Paz, Bolivia"
+          >
+            La Paz, Bolivia
+          </button>
+          <button
+            type="button"
+            role="listitem"
+            data-coords="35.3606,138.7274"
+            data-alt="7000"
+            data-label="Mount Fuji, Japan"
+          >
+            Mount Fuji, Japan
+          </button>
         </div>
       </div>
       <p class="safety-note">Ask a trusted adult to explore with you and zoom safely.</p>


### PR DESCRIPTION
## Summary
- add metadata to Google Earth hotspot buttons so latitude, longitude, altitude, and labels are available for the launcher
- update Google Earth launcher to use documented search and @-coordinate URLs that preload destinations and add iOS deep-link handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd658586ec8331834d4708fe6339c3